### PR TITLE
fix: PIZ1 create an order bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ migrations/
 pizza.sqlite
 .vscode/launch.json
 .vscode/tasks.json
+.idea/

--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,11 @@ def get_size_by_id(_id: int):
     response = size if not error else {"error": error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+
+@size.route("/", methods=GET)
+def get_sizes():
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {"error": error}
+    status_code = 200 if not error else 400
+    return jsonify(response), status_code

--- a/app/test/services/test_size.py
+++ b/app/test/services/test_size.py
@@ -20,10 +20,18 @@ def test_update_size_service(client, create_size, size_uri):
         pytest.assume(updated_size[param] == value)
 
 
-def test_get_size_by_id(client, create_size, size_uri):
+def test_get_size_by_id_service(client, create_size, size_uri):
     current_size = create_size.json
     response = client.get(f'{size_uri}id/{current_size["_id"]}')
     pytest.assume(response.status.startswith("200"))
     returned_size = response.json
     for param, value in current_size.items():
         pytest.assume(returned_size[param] == value)
+
+
+def test_get_sizes_service(client, create_sizes, size_uri):
+    current_sizes = create_sizes
+    response = client.get(size_uri)
+    pytest.assume(response.status.startswith("200"))
+    returned_sizes = response.json
+    pytest.assume(current_sizes == returned_sizes)


### PR DESCRIPTION
## Summary
Added new endpoint, so the bug where sizes are not showing on the FE is solved. Now. the sizes show and you can create an order.
**Before:**
![Frontend fails to get the resource](https://github.com/Mikkel-14/python-pizza-planet/assets/67567150/5396b726-2bb1-43ad-9798-76ff5f8a839b)
**After:**
![Frontend now gets the resource](https://github.com/Mikkel-14/python-pizza-planet/assets/67567150/8da85f5f-bb01-4193-b809-36de9c86e64a)

## Checklist
- [x] I created a new endpoint for querying the sizes on the frontend
- [x] I added a new test to cover the new endpoint
## Linked issues
- [PIZ1 trello](https://trello.com/c/h9d5mYmi)