### PR TITLE
fix: PIZ8 fixed OrderController

### DIFF
--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -11,7 +11,7 @@ class OrderController(BaseController):
 
     @staticmethod
     def calculate_order_price(size_price: float, ingredients: list):
-        price = sum(ingredient.price for ingredient in ingredients)
+        price = sum(ingredient.price for ingredient in ingredients) + size_price
         return round(price, 2)
 
     @classmethod

--- a/app/test/controllers/test_order.py
+++ b/app/test/controllers/test_order.py
@@ -41,7 +41,6 @@ def test_create(app, ingredients, size, client_data):
         pytest.assume(not ingredients_in_detail.difference(ingredient_ids))
 
 
-@pytest.mark.skip
 def test_calculate_order_price(app, ingredients, size, client_data):
     created_size, created_ingredients = __create_sizes_and_ingredients(ingredients, [size])
     order = __order(created_ingredients, created_size, client_data)


### PR DESCRIPTION
## Summary
Updaed the `calulate_order_price` method to include the size price
## Checklist
- [x] The size of the pizza is now being included on the total calculation
- [x] The failing test (previously skipped) now passes
## Linked issues
- (PIZ8 trello)[https://trello.com/c/kJMA09o9]